### PR TITLE
Use `product_name` in Order Item Payloads

### DIFF
--- a/app/assets/javascripts/workarea/storefront/google_tag_manager/modules/adapter.js
+++ b/app/assets/javascripts/workarea/storefront/google_tag_manager/modules/adapter.js
@@ -132,7 +132,7 @@ WORKAREA.analytics.registerAdapter('googleTagManager', function () {
                     'add': {
                         'products': [{
                             'id': payload.id,
-                            'name': payload.name,
+                            'name': payload.product_name,
                             'category': payload.category,
                             'variant': payload.sku,
                             'price': payload.price,
@@ -150,7 +150,7 @@ WORKAREA.analytics.registerAdapter('googleTagManager', function () {
                     'remove': {
                         'products': [{
                             'id': payload.id,
-                            'name': payload.name,
+                            'name': payload.product_name,
                             'category': payload.category,
                             'variant': payload.sku,
                             'price': payload.price,

--- a/test/javascripts/google_tag_manager_spec.js
+++ b/test/javascripts/google_tag_manager_spec.js
@@ -151,7 +151,7 @@
                     {
                         'category' : 'Automotive',
                         'id' : '4AF99AB7C8',
-                        'name' : 'Heavy Duty Iron Bag',
+                        'product_name' : 'Heavy Duty Iron Bag',
                         'price' : 80.76,
                         'quantity' : '1',
                         'sale' : false,
@@ -187,7 +187,7 @@
                     {
                         'category' : 'Automotive',
                         'id' : '4AF99AB7C8',
-                        'name' : 'Heavy Duty Iron Bag',
+                        'product_name' : 'Heavy Duty Iron Bag',
                         'price' : 80.76,
                         'quantity' : '1',
                         'sale' : false,


### PR DESCRIPTION
When the `addToCart` and `removeFromCart` analytics events are fired,
the payload is populated from the `#order_item_analytics_data` helper in
Ruby. This payload stores the product name in an attribute called
`product_name`, but the analytics adapter was written to use the `.name`
attribute, so when analytics events made it to GTM, they would not be
populated with the product name. To fix this, the `product_name` field
is now used in both the `addToCart` and `removeFromCart` analytics
events in the google tag manager adapter.